### PR TITLE
Replaced use of login2.datasektionen.se with login.datasektionen.se

### DIFF
--- a/verksamt/authviews.py
+++ b/verksamt/authviews.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseRedirect, Http404
 def login(request):
     if not request.user.is_authenticated:
         return HttpResponseRedirect(
-            'https://login2.datasektionen.se/login?callback=' +
+            'https://login.datasektionen.se/login?callback=' +
             request.scheme + '://' + request.get_host() + '/login/')
     else:
         return HttpResponseRedirect("/")

--- a/verksamt/dauth.py
+++ b/verksamt/dauth.py
@@ -11,7 +11,7 @@ class DAuth(object):
     @staticmethod
     def authenticate(token=None):
 
-        url = 'http://login2.datasektionen.se/verify/' + str(token) + '.json?api_key=' + settings.AUTH_API_KEY
+        url = 'https://login.datasektionen.se/verify/' + str(token) + '.json?api_key=' + settings.AUTH_API_KEY
         req = requests.get(url)
         if req.status_code == 200:
             data = req.json()

--- a/verksamt/settings.py
+++ b/verksamt/settings.py
@@ -122,7 +122,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-AUTH_API_KEY = os.getenv('LOGIN2_KEY', 'key-012345678910111213141516171819')
+AUTH_API_KEY = os.getenv('LOGIN_KEY', 'key-012345678910111213141516171819')
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/


### PR DESCRIPTION
Now `login.datasektionen.se` is used instead of `login2.datasektionen.se`.